### PR TITLE
Update rubocop, performance, add thread_safety and rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 inherit_from: config/default.yml
 
-require: rubocop-performance
+require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-thread_safety
 
 Style/Documentation:
   Enabled: false
@@ -8,15 +11,15 @@ Style/Documentation:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: ignore_implicit
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This gem houses RuboCop configuration files to be included in Silvercar Ruby projects.
 
+## Known Issues
+There's a typo in rubocop 0.77 that gives an invalid warning, which can be ignored.
+
+Warning: Style/TrivialAccessors does not support AllowedMethods parameter.
+
 ## Usage
 
 Add to gemfile:

--- a/README.md
+++ b/README.md
@@ -2,26 +2,6 @@
 
 This gem houses RuboCop configuration files to be included in Silvercar Ruby projects.
 
-# Branching Strategy
-
-This repository uses [GitHub flow](https://guides.github.com/introduction/flow/).
-
-* Feature branches should be Pull Requests opened against master.
-* Feature branches should begin with the JIRA ticket number
-
-# Pull Requests
-All code merged into master must be merged via a pull request.
-
-Pull requests must:
-
-* Have one or more reviewers
-* Be approved by one or more reviewers
-
-Pull requests should:
-
-* Be small, less than 2 days of work
-* Be merged by author after review process
-
 ## Usage
 
 Add to gemfile:
@@ -53,14 +33,14 @@ inherit_gem:
   silvercop: .rubocop.yml
 ```
 
-It is recommended to use this gem as `bundle exec rubocop -RD`, the two options being to run
-Rails cops as well as output the cop in question for that line of code.
+It is recommended to use this gem as `bundle exec rubocop -D`, which will output the violated
+cop for that line of code
 
 If many offenses are detected, it is recommended to generate a TODO list that can be handled over
 time without needing to fix all of the existing offenses. This can be done by generating and
 including the following config:
 
-`bundle exec rubocop -RD --auto-gen-config`
+`bundle exec rubocop -D --auto-gen-config`
 
 Then add `inherit_from: .rubocop_todo.yml` to your `.rubocop.yml` file. Adding `--exclude-limit 10000` can help prevent
 the generated config from disabling cops entirely with `Enabled: false`.

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,8 +1,8 @@
-# Common configuration.
 # This file was copied directly from https://github.com/rubocop-hq/rubocop/blob/v0.68.1/config/default.yml
 # That means it has more configuration than it needs, but it's easier to copy and paste into new versions
 # since we're just adopting everything in the new version.
 
+# Common configuration.
 AllCops:
   RubyInterpreters:
     - ruby
@@ -76,7 +76,7 @@ AllCops:
   DisplayStyleGuide: false
   # When specifying style guide URLs, any paths and/or fragments will be
   # evaluated relative to the base URL.
-  StyleGuideBaseURL: https://github.com/rubocop-hq/ruby-style-guide
+  StyleGuideBaseURL: https://rubystyle.guide
   # Extra details are not displayed in offense messages by default. Change
   # behavior by overriding ExtraDetails, or by giving the
   # `-E/--extra-details` option.
@@ -126,16 +126,8 @@ AllCops:
   # followed by the Gemfile.lock or gems.locked file. (Although the Ruby version
   # is specified in the Gemfile or gems.rb file, RuboCop reads the final value
   # from the lock file.) If the Ruby version is still unresolved, RuboCop will
-  # use the oldest officially supported Ruby version (currently Ruby 2.2).
+  # use the oldest officially supported Ruby version (currently Ruby 2.3).
   TargetRubyVersion: ~
-  # What version of Rails is the inspected code using?  If a value is specified
-  # for TargetRailsVersion then it is used. Acceptable values are specificed
-  # as a float (i.e. 5.1); the patch version of Rails should not be included.
-  # If TargetRailsVersion is not set, RuboCop will parse the Gemfile.lock or
-  # gems.locked file to find the version of Rails that has been bound to the
-  # application. If neither of those files exist, RuboCop will use Rails 5.0
-  # as the default.
-  TargetRailsVersion: ~
 
 #################### Bundler ###############################
 
@@ -152,11 +144,12 @@ Bundler/GemComment:
   Description: 'Add a comment describing each gem.'
   Enabled: false
   VersionAdded: '0.59'
+  VersionChanged: '0.77'
   Include:
     - '**/*.gemfile'
     - '**/Gemfile'
     - '**/gems.rb'
-  Whitelist: []
+  IgnoredGems: []
 
 Bundler/InsecureProtocolSource:
   Description: >-
@@ -206,6 +199,13 @@ Gemspec/RequiredRubyVersion:
   VersionAdded: '0.52'
   Include:
     - '**/*.gemspec'
+    -
+Gemspec/RubyVersionGlobalsUsage:
+  Description: Checks usage of RUBY_VERSION in gemspec.
+  Enabled: true
+  VersionAdded: '0.72'
+  Include:
+    - '**/*.gemspec'
 
 #################### Layout ###########################
 
@@ -222,13 +222,14 @@ Layout/AccessModifierIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Description: >-
                  Align the arguments of a method call if they span more
                  than one line.
   StyleGuide: '#no-double-indent'
   Enabled: true
   VersionAdded: '0.68'
+  VersionChanged: '0.77'
   # Alignment of arguments in multi-line method calls.
   #
   # The `with_first_argument` style aligns the following lines along the same
@@ -250,116 +251,23 @@ Layout/AlignArguments:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Description: >-
                  Align the elements of an array literal if they span more than
                  one line.
   StyleGuide: '#align-multiline-arrays'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '0.77'
 
-Layout/AlignHash:
+Layout/AssignmentIndentation:
   Description: >-
-                 Align the elements of a hash literal if they span more than
-                 one line.
+                Checks the indentation of the first line of the
+                right-hand-side of a multi-line assignment.
   Enabled: true
   VersionAdded: '0.49'
-  # Alignment of entries using hash rocket as separator. Valid values are:
-  #
-  # key - left alignment of keys
-  #   'a' => 2
-  #   'bb' => 3
-  # separator - alignment of hash rockets, keys are right aligned
-  #    'a' => 2
-  #   'bb' => 3
-  # table - left alignment of keys, hash rockets, and values
-  #   'a'  => 2
-  #   'bb' => 3
-  EnforcedHashRocketStyle: key
-  SupportedHashRocketStyles:
-    - key
-    - separator
-    - table
-  # Alignment of entries using colon as separator. Valid values are:
-  #
-  # key - left alignment of keys
-  #   a: 0
-  #   bb: 1
-  # separator - alignment of colons, keys are right aligned
-  #    a: 0
-  #   bb: 1
-  # table - left alignment of keys and values
-  #   a:  0
-  #   bb: 1
-  EnforcedColonStyle: key
-  SupportedColonStyles:
-    - key
-    - separator
-    - table
-  # Select whether hashes that are the last argument in a method call should be
-  # inspected? Valid values are:
-  #
-  # always_inspect - Inspect both implicit and explicit hashes.
-  #   Registers an offense for:
-  #     function(a: 1,
-  #       b: 2)
-  #   Registers an offense for:
-  #     function({a: 1,
-  #       b: 2})
-  # always_ignore - Ignore both implicit and explicit hashes.
-  #   Accepts:
-  #     function(a: 1,
-  #       b: 2)
-  #   Accepts:
-  #     function({a: 1,
-  #       b: 2})
-  # ignore_implicit - Ignore only implicit hashes.
-  #   Accepts:
-  #     function(a: 1,
-  #       b: 2)
-  #   Registers an offense for:
-  #     function({a: 1,
-  #       b: 2})
-  # ignore_explicit - Ignore only explicit hashes.
-  #   Accepts:
-  #     function({a: 1,
-  #       b: 2})
-  #   Registers an offense for:
-  #     function(a: 1,
-  #       b: 2)
-  EnforcedLastArgumentHashStyle: always_inspect
-  SupportedLastArgumentHashStyles:
-    - always_inspect
-    - always_ignore
-    - ignore_implicit
-    - ignore_explicit
-
-Layout/AlignParameters:
-  Description: >-
-                 Align the parameters of a method definition if they span more
-                 than one line.
-  StyleGuide: '#no-double-indent'
-  Enabled: true
-  VersionAdded: '0.49'
-  VersionChanged: '0.68'
-  # Alignment of parameters in multi-line method calls.
-  #
-  # The `with_first_parameter` style aligns the following lines along the same
-  # column as the first parameter.
-  #
-  #     def method_foo(a,
-  #                    b)
-  #
-  # The `with_fixed_indentation` style aligns the following lines with one
-  # level of indentation relative to the start of the line with the method call.
-  #
-  #     def method_foo(a,
-  #       b)
-  EnforcedStyle: with_first_parameter
-  SupportedStyles:
-    - with_first_parameter
-    - with_fixed_indentation
-  # By default, the indentation width from Layout/IndentationWidth is used
+  VersionChanged: '0.77'
+  # By default, the indentation width from `Layout/IndentationWidth` is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
@@ -511,6 +419,13 @@ Layout/EmptyLinesAroundAccessModifier:
   StyleGuide: '#empty-lines-around-access-modifier'
   Enabled: true
   VersionAdded: '0.49'
+  EnforcedStyle: around
+  SupportedStyles:
+    - around
+    - only_before
+  Reference:
+    # A reference to `EnforcedStyle: only_before`.
+    - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
 
 Layout/EmptyLinesAroundArguments:
   Description: "Keeps track of empty lines around method arguments."
@@ -620,12 +535,89 @@ Layout/ExtraSpacing:
   # When true, forces the alignment of `=` in assignments on consecutive lines.
   ForceEqualSignAlignment: false
 
+Layout/FirstArgumentIndentation:
+  Description: 'Checks the indentation of the first argument in a method call.'
+  Enabled: true
+  VersionAdded: '0.68'
+  VersionChanged: '0.77'
+  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  SupportedStyles:
+    # The first parameter should always be indented one step more than the
+    # preceding line.
+    - consistent
+    # The first parameter should always be indented one level relative to the
+    # parent that is receiving the parameter
+    - consistent_relative_to_receiver
+    # The first parameter should normally be indented one step more than the
+    # preceding line, but if it's a parameter for a method call that is itself
+    # a parameter in a method call, then the inner parameter should be indented
+    # relative to the inner method.
+    - special_for_inner_method_call
+    # Same as `special_for_inner_method_call` except that the special rule only
+    # applies if the outer method call encloses its arguments in parentheses.
+    - special_for_inner_method_call_in_parentheses
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Layout/FirstArrayElementIndentation:
+  Description: >-
+                 Checks the indentation of the first element in an array
+                 literal.
+  Enabled: true
+  VersionAdded: '0.68'
+  VersionChanged: '0.77'
+  # The value `special_inside_parentheses` means that array literals with
+  # brackets that have their opening bracket on the same line as a surrounding
+  # opening round parenthesis, shall have their first element indented relative
+  # to the first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first element shall
+  # always be relative to the first position of the line where the opening
+  # bracket is.
+  #
+  # The value `align_brackets` means that the indentation of the first element
+  # shall always be relative to the position of the opening bracket.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
 Layout/FirstArrayElementLineBreak:
   Description: >-
                  Checks for a line break before the first element in a
                  multi-line array.
   Enabled: false
   VersionAdded: '0.49'
+
+Layout/FirstHashElementIndentation:
+  Description: 'Checks the indentation of the first key in a hash literal.'
+  Enabled: true
+  VersionAdded: '0.68'
+  VersionChanged: '0.77'
+  # The value `special_inside_parentheses` means that hash literals with braces
+  # that have their opening brace on the same line as a surrounding opening
+  # round parenthesis, shall have their first key indented relative to the
+  # first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first key shall
+  # always be relative to the first position of the line where the opening
+  # brace is.
+  #
+  # The value `align_braces` means that the indentation of the first key shall
+  # always be relative to the position of the opening brace.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_braces
+  # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
 
 Layout/FirstHashElementLineBreak:
   Description: >-
@@ -648,105 +640,13 @@ Layout/FirstMethodParameterLineBreak:
   Enabled: false
   VersionAdded: '0.49'
 
-Layout/HeredocArgumentClosingParenthesis:
-  Description: >-
-                 Checks for the placement of the closing parenthesis in a
-                 method call that passes a HEREDOC string as an argument.
-  Enabled: false
-  StyleGuide: '#heredoc-argument-closing-parentheses'
-  VersionAdded: '0.68'
-
-Layout/IndentAssignment:
-  Description: >-
-                 Checks the indentation of the first line of the
-                 right-hand-side of a multi-line assignment.
-  Enabled: true
-  VersionAdded: '0.49'
-  # By default, the indentation width from `Layout/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
-
-Layout/IndentFirstArgument:
-  Description: 'Checks the indentation of the first argument in a method call.'
-  Enabled: true
-  VersionAdded: '0.68'
-  EnforcedStyle: special_for_inner_method_call_in_parentheses
-  SupportedStyles:
-    # The first parameter should always be indented one step more than the
-    # preceding line.
-    - consistent
-    # The first parameter should always be indented one level relative to the
-    # parent that is receiving the parameter
-    - consistent_relative_to_receiver
-    # The first parameter should normally be indented one step more than the
-    # preceding line, but if it's a parameter for a method call that is itself
-    # a parameter in a method call, then the inner parameter should be indented
-    # relative to the inner method.
-    - special_for_inner_method_call
-    # Same as `special_for_inner_method_call` except that the special rule only
-    # applies if the outer method call encloses its arguments in parentheses.
-    - special_for_inner_method_call_in_parentheses
-  # By default, the indentation width from `Layout/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
-
-Layout/IndentFirstArrayElement:
-  Description: >-
-                 Checks the indentation of the first element in an array
-                 literal.
-  Enabled: true
-  VersionAdded: '0.68'
-  # The value `special_inside_parentheses` means that array literals with
-  # brackets that have their opening bracket on the same line as a surrounding
-  # opening round parenthesis, shall have their first element indented relative
-  # to the first position inside the parenthesis.
-  #
-  # The value `consistent` means that the indentation of the first element shall
-  # always be relative to the first position of the line where the opening
-  # bracket is.
-  #
-  # The value `align_brackets` means that the indentation of the first element
-  # shall always be relative to the position of the opening bracket.
-  EnforcedStyle: special_inside_parentheses
-  SupportedStyles:
-    - special_inside_parentheses
-    - consistent
-    - align_brackets
-  # By default, the indentation width from `Layout/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
-
-Layout/IndentFirstHashElement:
-  Description: 'Checks the indentation of the first key in a hash literal.'
-  Enabled: true
-  VersionAdded: '0.68'
-  # The value `special_inside_parentheses` means that hash literals with braces
-  # that have their opening brace on the same line as a surrounding opening
-  # round parenthesis, shall have their first key indented relative to the
-  # first position inside the parenthesis.
-  #
-  # The value `consistent` means that the indentation of the first key shall
-  # always be relative to the first position of the line where the opening
-  # brace is.
-  #
-  # The value `align_braces` means that the indentation of the first key shall
-  # always be relative to the position of the opening brace.
-  EnforcedStyle: special_inside_parentheses
-  SupportedStyles:
-    - special_inside_parentheses
-    - consistent
-    - align_braces
-  # By default, the indentation width from `Layout/IndentationWidth` is used
-  # But it can be overridden by setting this parameter
-  IndentationWidth: ~
-
-Layout/IndentFirstParameter:
+Layout/FirstParameterIndentation:
   Description: >-
                  Checks the indentation of the first parameter in a
                  method definition.
   Enabled: true
   VersionAdded: '0.49'
-  VersionChanged: '0.68'
+  VersionChanged: '0.77'
   EnforcedStyle: consistent
   SupportedStyles:
     - consistent
@@ -755,14 +655,100 @@ Layout/IndentFirstParameter:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
-Layout/IndentHeredoc:
+Layout/HashAlignment:
+  Description: >-
+    Align the elements of a hash literal if they span more than
+    one line.
+  Enabled: true
+  AllowMultipleStyles: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  # Alignment of entries using hash rocket as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   'a' => 2
+  #   'bb' => 3
+  # separator - alignment of hash rockets, keys are right aligned
+  #    'a' => 2
+  #   'bb' => 3
+  # table - left alignment of keys, hash rockets, and values
+  #   'a'  => 2
+  #   'bb' => 3
+  EnforcedHashRocketStyle: key
+  SupportedHashRocketStyles:
+    - key
+    - separator
+    - table
+  # Alignment of entries using colon as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   a: 0
+  #   bb: 1
+  # separator - alignment of colons, keys are right aligned
+  #    a: 0
+  #   bb: 1
+  # table - left alignment of keys and values
+  #   a:  0
+  #   bb: 1
+  EnforcedColonStyle: key
+  SupportedColonStyles:
+    - key
+    - separator
+    - table
+  # Select whether hashes that are the last argument in a method call should be
+  # inspected? Valid values are:
+  #
+  # always_inspect - Inspect both implicit and explicit hashes.
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # always_ignore - Ignore both implicit and explicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_implicit - Ignore only implicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_explicit - Ignore only explicit hashes.
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  EnforcedLastArgumentHashStyle: always_inspect
+  SupportedLastArgumentHashStyles:
+    - always_inspect
+    - always_ignore
+    - ignore_implicit
+    - ignore_explicit
+
+Layout/HeredocArgumentClosingParenthesis:
+  Description: >-
+                 Checks for the placement of the closing parenthesis in a
+                 method call that passes a HEREDOC string as an argument.
+  Enabled: false
+  StyleGuide: '#heredoc-argument-closing-parentheses'
+  VersionAdded: '0.68'
+
+Layout/HeredocIndentation:
   Description: 'This cop checks the indentation of the here document bodies.'
   StyleGuide: '#squiggly-heredocs'
   Enabled: true
   VersionAdded: '0.49'
-  EnforcedStyle: auto_detection
+  VersionChanged: '0.77'
+  EnforcedStyle: squiggly
   SupportedStyles:
-    - auto_detection
     - squiggly
     - active_support
     - powerpack
@@ -773,8 +759,8 @@ Layout/IndentationConsistency:
   StyleGuide: '#spaces-indentation'
   Enabled: true
   VersionAdded: '0.49'
-  # The difference between `rails` and `normal` is that the `rails` style
-  # prescribes that in classes and modules the `protected` and `private`
+  # The difference between `indented` and `normal` is that the `indented_internal_methods`
+  # style prescribes that in classes and modules the `protected` and `private`
   # modifier keywords shall be indented the same as public methods and that
   # protected and private members shall be indented one step more than the
   # modifiers. Other than that, both styles mean that entities on the same
@@ -782,7 +768,10 @@ Layout/IndentationConsistency:
   EnforcedStyle: normal
   SupportedStyles:
     - normal
-    - rails
+    - indented_internal_methods
+  Reference:
+    # A reference to `EnforcedStyle: indented_internal_methods`.
+    - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
 
 Layout/IndentationWidth:
   Description: 'Use 2 spaces for indentation.'
@@ -799,16 +788,19 @@ Layout/InitialIndentation:
   Enabled: true
   VersionAdded: '0.49'
 
-Layout/LeadingBlankLines:
-  Description: Check for unnecessary blank lines at the beginning of a file.
-  Enabled: true
-  VersionAdded: '0.57'
-
 Layout/LeadingCommentSpace:
   Description: 'Comments should start with a space.'
   StyleGuide: '#hash-space'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '0.73'
+  AllowDoxygenCommentStyle: false
+
+Layout/LeadingEmptyLines:
+  Description: Check for unnecessary blank lines at the beginning of a file.
+  Enabled: true
+  VersionAdded: '0.57'
+  VersionChanged: '0.77'
 
 Layout/MultilineArrayBraceLayout:
   Description: >-
@@ -948,6 +940,35 @@ Layout/MultilineOperationIndentation:
     - aligned
     - indented
   # By default, the indentation width from `Layout/IndentationWidth` is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Layout/ParameterAlignment:
+  Description: >-
+                 Align the parameters of a method definition if they span more
+                 than one line.
+  StyleGuide: '#no-double-indent'
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  # Alignment of parameters in multi-line method calls.
+  #
+  # The `with_first_parameter` style aligns the following lines along the same
+  # column as the first parameter.
+  #
+  #     def method_foo(a,
+  #                    b)
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with the method call.
+  #
+  #     def method_foo(a,
+  #       b)
+  EnforcedStyle: with_first_parameter
+  SupportedStyles:
+    - with_first_parameter
+    - with_fixed_indentation
+  # By default, the indentation width from Layout/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
@@ -1193,11 +1214,12 @@ Layout/Tab:
   # replace each tab.
   IndentationWidth: ~
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   Description: 'Checks trailing blank lines and final newline.'
   StyleGuide: '#newline-eof'
   Enabled: true
   VersionAdded: '0.49'
+  VersionChanged: '0.77'
   EnforcedStyle: final_newline
   SupportedStyles:
     - final_newline
@@ -1281,15 +1303,16 @@ Lint/DuplicateCaseCondition:
   Enabled: true
   VersionAdded: '0.45'
 
+Lint/DuplicateHashKey:
+  Description: 'Check for duplicate keys in hash literals.'
+  Enabled: true
+  VersionAdded: '0.34'
+  VersionChanged: '0.77'
+
 Lint/DuplicateMethods:
   Description: 'Check for duplicate method definitions.'
   Enabled: true
   VersionAdded: '0.29'
-
-Lint/DuplicatedKey:
-  Description: 'Check for duplicate keys in hash literals.'
-  Enabled: true
-  VersionAdded: '0.34'
 
 Lint/EachWithObjectArgument:
   Description: 'Check for immutable argument given to each_with_object.'
@@ -1341,7 +1364,7 @@ Lint/ErbNewArguments:
   VersionAdded: '0.56'
 
 Lint/FlipFlop:
-  Description: 'Checks for flip-flops'
+  Description: 'Checks for flip-flops.'
   StyleGuide: '#no-flip-flops'
   Enabled: true
   VersionAdded: '0.16'
@@ -1357,12 +1380,6 @@ Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
   Enabled: true
   VersionAdded: '0.33'
-
-Lint/HandleExceptions:
-  Description: "Don't suppress exception."
-  StyleGuide: '#dont-hide-exceptions'
-  Enabled: true
-  VersionAdded: '0.9'
 
 Lint/HeredocMethodCallPosition:
   Description: >-
@@ -1397,7 +1414,7 @@ Lint/InheritException:
     - standard_error
 
 Lint/InterpolationCheck:
-  Description: 'Raise warning for interpolation in single q strs'
+  Description: 'Raise warning for interpolation in single q strs.'
   Enabled: true
   VersionAdded: '0.50'
 
@@ -1421,7 +1438,7 @@ Lint/Loop:
   VersionAdded: '0.9'
 
 Lint/MissingCopEnableDirective:
-  Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`'
+  Description: 'Checks for a `# rubocop:enable` after `# rubocop:disable`.'
   Enabled: true
   VersionAdded: '0.52'
   # Maximum number of consecutive lines the cop can be disabled for.
@@ -1433,10 +1450,11 @@ Lint/MissingCopEnableDirective:
   # .inf for any size
   MaximumRangeSize: .inf
 
-Lint/MultipleCompare:
-  Description: "Use `&&` operator to compare multiple value."
+Lint/MultipleComparison:
+  Description: "Use `&&` operator to compare multiple values."
   Enabled: true
   VersionAdded: '0.47'
+  VersionChanged: '0.77'
 
 Lint/NestedMethodDefinition:
   Description: 'Do not use nested method definitions.'
@@ -1465,6 +1483,8 @@ Lint/NumberConversion:
   Description: 'Checks unsafe usage of number conversion methods.'
   Enabled: false
   VersionAdded: '0.53'
+  VersionChanged: '0.70'
+  SafeAutoCorrect: false
 
 Lint/OrderedMagicComments:
   Description: 'Checks the proper ordering of magic comments and whether a magic comment is not placed before a shebang.'
@@ -1483,6 +1503,7 @@ Lint/PercentStringArray:
   Description: >-
                  Checks for unwanted commas and quotes in %w/%W literals.
   Enabled: true
+  Safe: false
   VersionAdded: '0.41'
 
 Lint/PercentSymbolArray:
@@ -1497,6 +1518,36 @@ Lint/RandOne:
                  and most likely a mistake.
   Enabled: true
   VersionAdded: '0.36'
+
+Lint/RedundantCopDisableDirective:
+  Description: >-
+                 Checks for rubocop:disable comments that can be removed.
+                 Note: this cop is not disabled when disabling all cops.
+                 It must be explicitly disabled.
+  Enabled: true
+  VersionAdded: '0.76'
+
+Lint/RedundantCopEnableDirective:
+  Description: Checks for rubocop:enable comments that can be removed.
+  Enabled: true
+  VersionAdded: '0.76'
+
+Lint/RedundantRequireStatement:
+  Description: 'Checks for unnecessary `require` statement.'
+  Enabled: true
+  VersionAdded: '0.76'
+
+Lint/RedundantSplatExpansion:
+  Description: 'Checks for splat unnecessarily being called on literals.'
+  Enabled: true
+  VersionChanged: '0.76'
+
+Lint/RedundantStringCoercion:
+  Description: 'Checks for Object#to_s usage in string interpolation.'
+  StyleGuide: '#no-to-s'
+  Enabled: true
+  VersionAdded: '0.19'
+  VersionChanged: '0.77'
 
 Lint/RedundantWithIndex:
   Description: 'Checks for redundant `with_index`.'
@@ -1543,8 +1594,8 @@ Lint/SafeNavigationChain:
   Description: 'Do not chain ordinary method call after safe navigation operator.'
   Enabled: true
   VersionAdded: '0.47'
-  VersionChanged: '0.56'
-  Whitelist:
+  VersionChanged: '0.77'
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -1558,13 +1609,13 @@ Lint/SafeNavigationConsistency:
                  for all method calls on that same object.
   Enabled: true
   VersionAdded: '0.55'
-  Whitelist:
+  VersionChanged: '0.77'
+  AllowedMethods:
     - present?
     - blank?
     - presence
     - try
     - try!
-
 
 Lint/SafeNavigationWithEmpty:
   Description: 'Avoid `foo&.empty?` in conditionals.'
@@ -1576,6 +1627,11 @@ Lint/ScriptPermission:
   Enabled: true
   VersionAdded: '0.49'
   VersionChanged: '0.50'
+
+Lint/SendWithMixinArgument:
+  Description: 'Checks for `send` method when using mixin.'
+  Enabled: true
+  VersionAdded: '0.75'
 
 Lint/ShadowedArgument:
   Description: 'Avoid reassigning arguments before they were used.'
@@ -1598,15 +1654,16 @@ Lint/ShadowingOuterLocalVariable:
   Enabled: true
   VersionAdded: '0.9'
 
-Lint/StringConversionInInterpolation:
-  Description: 'Checks for Object#to_s usage in string interpolation.'
-  StyleGuide: '#no-to-s'
+Lint/SuppressedException:
+  Description: "Don't suppress exceptions."
+  StyleGuide: '#dont-hide-exceptions'
   Enabled: true
-  VersionAdded: '0.19'
-  VersionChanged: '0.20'
+  AllowComments: false
+  VersionAdded: '0.9'
+  VersionChanged: '0.77'
 
 Lint/Syntax:
-  Description: 'Checks syntax error'
+  Description: 'Checks syntax error.'
   Enabled: true
   VersionAdded: '0.9'
 
@@ -1622,30 +1679,7 @@ Lint/UnderscorePrefixedVariableName:
   AllowKeywordBlockArguments: false
 
 Lint/UnifiedInteger:
-  Description: 'Use Integer instead of Fixnum or Bignum'
-  Enabled: true
-  VersionAdded: '0.43'
-
-Lint/UnneededCopDisableDirective:
-  Description: >-
-                 Checks for rubocop:disable comments that can be removed.
-                 Note: this cop is not disabled when disabling all cops.
-                 It must be explicitly disabled.
-  Enabled: true
-  VersionAdded: '0.53'
-
-Lint/UnneededCopEnableDirective:
-  Description: Checks for rubocop:enable comments that can be removed.
-  Enabled: true
-  VersionAdded: '0.53'
-
-Lint/UnneededRequireStatement:
-  Description: 'Checks for unnecessary `require` statement.'
-  Enabled: true
-  VersionAdded: '0.51'
-
-Lint/UnneededSplatExpansion:
-  Description: 'Checks for splat unnecessarily being called on literals'
+  Description: 'Use Integer instead of Fixnum or Bignum.'
   Enabled: true
   VersionAdded: '0.43'
 
@@ -1731,7 +1765,7 @@ Metrics/AbcSize:
                  branches, and conditions.
   Reference:
     - http://c2.com/cgi/wiki?AbcMetric
-    - https://en.wikipedia.org/wiki/ABC_Software_Metric'
+    - https://en.wikipedia.org/wiki/ABC_Software_Metric
   Enabled: true
   VersionAdded: '0.27'
   VersionChanged: '0.66'
@@ -1754,7 +1788,7 @@ Metrics/BlockLength:
     - '**/*.gemspec'
 
 Metrics/BlockNesting:
-  Description: 'Avoid excessive block nesting'
+  Description: 'Avoid excessive block nesting.'
   StyleGuide: '#three-is-the-number-thou-shalt-count'
   Enabled: true
   VersionAdded: '0.25'
@@ -1795,7 +1829,7 @@ Metrics/LineLength:
     - https
   # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
   # directives like '# rubocop: enable ...' when calculating a line's length.
-  IgnoreCopDirectives: false
+  IgnoreCopDirectives: true
   # The IgnoredPatterns option is a list of !ruby/regexp and/or string
   # elements. Strings will be converted to Regexp objects. A line that matches
   # any regular expression listed in this option will be ignored by LineLength.
@@ -1834,6 +1868,14 @@ Metrics/PerceivedComplexity:
   VersionAdded: '0.25'
   Max: 7
 
+################## Migration #############################
+
+Migration/DepartmentName:
+  Description: >-
+                 Check that cop names in rubocop:disable (etc) comments are
+                 given with department name.
+  Enabled: false
+
 #################### Naming ##############################
 
 Naming/AccessorMethodName:
@@ -1853,6 +1895,21 @@ Naming/BinaryOperatorParameterName:
   StyleGuide: '#other-arg'
   Enabled: true
   VersionAdded: '0.50'
+
+Naming/BlockParameterName:
+  Description: >-
+                 Checks for block parameter names that contain capital letters,
+                 end in numbers, or do not meet a minimal length.
+  Enabled: true
+  VersionAdded: '0.53'
+  VersionChanged: '0.77'
+  # Parameter names may be equal to or greater than this value
+  MinNameLength: 1
+  AllowNamesEndingInNumbers: true
+  # Allowed names that will not register an offense
+  AllowedNames: []
+  # Forbidden names that will register an offense
+  ForbiddenNames: []
 
 Naming/ClassAndModuleCamelCase:
   Description: 'Use CamelCase for classes and modules.'
@@ -1945,7 +2002,7 @@ Naming/HeredocDelimiterNaming:
   StyleGuide: '#heredoc-delimiters'
   Enabled: true
   VersionAdded: '0.50'
-  Blacklist:
+  ForbiddenDelimiters:
     - !ruby/regexp '/(^|\s)(EO[A-Z]{1}|END)(\s|$)/'
 
 Naming/MemoizedInstanceVariableName:
@@ -1969,26 +2026,58 @@ Naming/MethodName:
   SupportedStyles:
     - snake_case
     - camelCase
+  # Method names matching patterns are always allowed.
+  #
+  #   IgnoredPatterns:
+  #     - '\A\s*onSelectionBulkChange\s*'
+  #     - '\A\s*onSelectionCleared\s*'
+  #
+  IgnoredPatterns: []
+
+Naming/MethodParameterName:
+  Description: >-
+                 Checks for method parameter names that contain capital letters,
+                 end in numbers, or do not meet a minimal length.
+  Enabled: true
+  VersionAdded: '0.53'
+  VersionChanged: '0.77'
+  # Parameter names may be equal to or greater than this value
+  MinNameLength: 3
+  AllowNamesEndingInNumbers: true
+  # Allowed names that will not register an offense
+  AllowedNames:
+    - io
+    - id
+    - to
+    - by
+    - 'on'
+    - in
+    - at
+    - ip
+    - db
+    - os
+  # Forbidden names that will register an offense
+  ForbiddenNames: []
 
 Naming/PredicateName:
   Description: 'Check the names of predicate methods.'
   StyleGuide: '#bool-methods-qmark'
   Enabled: true
   VersionAdded: '0.50'
-  VersionChanged: '0.51'
+  VersionChanged: '0.77'
   # Predicate name prefixes.
   NamePrefix:
     - is_
     - has_
     - have_
   # Predicate name prefixes that should be removed.
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
     - has_
     - have_
-  # Predicate names which, despite having a blacklisted prefix, or no `?`,
+  # Predicate names which, despite having a forbidden prefix, or no `?`,
   # should still be accepted
-  NameWhitelist:
+  AllowedMethods:
     - is_a?
   # Method definition macros for dynamically generated methods.
   MethodDefinitionMacros:
@@ -2005,45 +2094,6 @@ Naming/RescuedExceptionsVariableName:
   VersionAdded: '0.67'
   VersionChanged: '0.68'
   PreferredName: e
-
-Naming/UncommunicativeBlockParamName:
-  Description: >-
-                Checks for block parameter names that contain capital letters,
-                end in numbers, or do not meet a minimal length.
-  Enabled: true
-  VersionAdded: '0.53'
-  # Parameter names may be equal to or greater than this value
-  MinNameLength: 1
-  AllowNamesEndingInNumbers: true
-  # Whitelisted names that will not register an offense
-  AllowedNames: []
-  # Blacklisted names that will register an offense
-  ForbiddenNames: []
-
-Naming/UncommunicativeMethodParamName:
-  Description: >-
-                Checks for method parameter names that contain capital letters,
-                end in numbers, or do not meet a minimal length.
-  Enabled: true
-  VersionAdded: '0.53'
-  VersionChanged: '0.59'
-  # Parameter names may be equal to or greater than this value
-  MinNameLength: 3
-  AllowNamesEndingInNumbers: true
-  # Whitelisted names that will not register an offense
-  AllowedNames:
-    - io
-    - id
-    - to
-    - by
-    - 'on'
-    - in
-    - at
-    - ip
-    - db
-  # Blacklisted names that will register an offense
-  ForbiddenNames: []
-
 
 Naming/VariableName:
   Description: 'Use the configured style when naming variables.'
@@ -2064,458 +2114,6 @@ Naming/VariableNumber:
     - snake_case
     - normalcase
     - non_integer
-
-#################### Rails #################################
-
-# By default, the rails cops are not run. Override in project or home
-# directory .rubocop.yml files, or by giving the -R/--rails option.
-Rails:
-  Enabled: false
-
-Rails/ActionFilter:
-  Description: 'Enforces consistent use of action filter methods.'
-  Enabled: true
-  VersionAdded: '0.19'
-  EnforcedStyle: action
-  SupportedStyles:
-    - action
-    - filter
-  Include:
-    - app/controllers/**/*.rb
-
-Rails/ActiveRecordAliases:
-  Description: >-
-                  Avoid Active Record aliases:
-                  Use `update` instead of `update_attributes`.
-                  Use `update!` instead of `update_attributes!`.
-  Enabled: true
-  VersionAdded: '0.53'
-
-Rails/ActiveRecordOverride:
-  Description: >-
-                  Check for overriding Active Record methods instead of using
-                  callbacks.
-  Enabled: true
-  VersionAdded: '0.67'
-  Include:
-    - app/models/**/*.rb
-
-Rails/ActiveSupportAliases:
-  Description: >-
-                  Avoid ActiveSupport aliases of standard ruby methods:
-                  `String#starts_with?`, `String#ends_with?`,
-                  `Array#append`, `Array#prepend`.
-  Enabled: true
-  VersionAdded: '0.48'
-
-Rails/ApplicationJob:
-  Description: 'Check that jobs subclass ApplicationJob.'
-  Enabled: true
-  VersionAdded: '0.49'
-
-Rails/ApplicationRecord:
-  Description: 'Check that models subclass ApplicationRecord.'
-  Enabled: true
-  VersionAdded: '0.49'
-
-Rails/AssertNot:
-  Description: 'Use `assert_not` instead of `assert !`.'
-  Enabled: true
-  VersionAdded: '0.56'
-  Include:
-    - '**/test/**/*'
-
-Rails/BelongsTo:
-  Description: >-
-                  Use `optional: true` instead of `required: false` for
-                  `belongs_to` relations'
-  Enabled: true
-  VersionAdded: '0.62'
-
-Rails/Blank:
-  Description: 'Enforces use of `blank?`.'
-  Enabled: true
-  VersionAdded: '0.48'
-  VersionChanged: '0.67'
-  # Convert usages of `nil? || empty?` to `blank?`
-  NilOrEmpty: true
-  # Convert usages of `!present?` to `blank?`
-  NotPresent: true
-  # Convert usages of `unless present?` to `if blank?`
-  UnlessPresent: true
-
-Rails/BulkChangeTable:
-  Description: 'Check whether alter queries are combinable.'
-  Enabled: true
-  VersionAdded: '0.57'
-  Database: null
-  SupportedDatabases:
-    - mysql
-    - postgresql
-  Include:
-    - db/migrate/*.rb
-
-Rails/CreateTableWithTimestamps:
-  Description: >-
-                  Checks the migration for which timestamps are not included
-                  when creating a new table.
-  Enabled: true
-  VersionAdded: '0.52'
-  Include:
-    - db/migrate/*.rb
-
-Rails/Date:
-  Description: >-
-                  Checks the correct usage of date aware methods,
-                  such as Date.today, Date.current etc.
-  Enabled: true
-  VersionAdded: '0.30'
-  VersionChanged: '0.33'
-  # The value `strict` disallows usage of `Date.today`, `Date.current`,
-  # `Date#to_time` etc.
-  # The value `flexible` allows usage of `Date.current`, `Date.yesterday`, etc
-  # (but not `Date.today`) which are overridden by ActiveSupport to handle current
-  # time zone.
-  EnforcedStyle: flexible
-  SupportedStyles:
-    - strict
-    - flexible
-
-Rails/Delegate:
-  Description: 'Prefer delegate method for delegations.'
-  Enabled: true
-  VersionAdded: '0.21'
-  VersionChanged: '0.50'
-  # When set to true, using the target object as a prefix of the
-  # method name without using the `delegate` method will be a
-  # violation. When set to false, this case is legal.
-  EnforceForPrefixed: true
-
-Rails/DelegateAllowBlank:
-  Description: 'Do not use allow_blank as an option to delegate.'
-  Enabled: true
-  VersionAdded: '0.44'
-
-Rails/DynamicFindBy:
-  Description: 'Use `find_by` instead of dynamic `find_by_*`.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find_by'
-  Enabled: true
-  VersionAdded: '0.44'
-  Whitelist:
-    - find_by_sql
-
-Rails/EnumUniqueness:
-  Description: 'Avoid duplicate integers in hash-syntax `enum` declaration.'
-  Enabled: true
-  VersionAdded: '0.46'
-  Include:
-    - app/models/**/*.rb
-
-Rails/EnvironmentComparison:
-  Description: "Favor `Rails.env.production?` over `Rails.env == 'production'`"
-  Enabled: true
-  VersionAdded: '0.52'
-
-Rails/Exit:
-  Description: >-
-                  Favor `fail`, `break`, `return`, etc. over `exit` in
-                  application or library code outside of Rake files to avoid
-                  exits during unit testing or running in production.
-  Enabled: true
-  VersionAdded: '0.41'
-  Include:
-    - app/**/*.rb
-    - config/**/*.rb
-    - lib/**/*.rb
-  Exclude:
-    - lib/**/*.rake
-
-Rails/FilePath:
-  Description: 'Use `Rails.root.join` for file path joining.'
-  Enabled: true
-  VersionAdded: '0.47'
-  VersionChanged: '0.57'
-  EnforcedStyle: arguments
-  SupportedStyles:
-    - slashes
-    - arguments
-
-Rails/FindBy:
-  Description: 'Prefer find_by over where.first.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find_by'
-  Enabled: true
-  VersionAdded: '0.30'
-  Include:
-    - app/models/**/*.rb
-
-Rails/FindEach:
-  Description: 'Prefer all.find_each over all.find.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#find-each'
-  Enabled: true
-  VersionAdded: '0.30'
-  Include:
-    - app/models/**/*.rb
-
-Rails/HasAndBelongsToMany:
-  Description: 'Prefer has_many :through to has_and_belongs_to_many.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#has-many-through'
-  Enabled: true
-  VersionAdded: '0.12'
-  Include:
-    - app/models/**/*.rb
-
-Rails/HasManyOrHasOneDependent:
-  Description: 'Define the dependent option to the has_many and has_one associations.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#has_many-has_one-dependent-option'
-  Enabled: true
-  VersionAdded: '0.50'
-  Include:
-    - app/models/**/*.rb
-
-Rails/HttpPositionalArguments:
-  Description: 'Use keyword arguments instead of positional arguments in http method calls.'
-  Enabled: true
-  VersionAdded: '0.44'
-  Include:
-    - 'spec/**/*'
-    - 'test/**/*'
-
-Rails/HttpStatus:
-  Description: 'Enforces use of symbolic or numeric value to define HTTP status.'
-  Enabled: true
-  VersionAdded: '0.54'
-  EnforcedStyle: symbolic
-  SupportedStyles:
-    - numeric
-    - symbolic
-
-Rails/IgnoredSkipActionFilterOption:
-  Description: 'Checks that `if` and `only` (or `except`) are not used together as options of `skip_*` action filter.'
-  Reference: 'https://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-_normalize_callback_options'
-  Enabled: true
-  VersionAdded: '0.63'
-  Include:
-    - app/controllers/**/*.rb
-
-Rails/InverseOf:
-  Description: 'Checks for associations where the inverse cannot be determined automatically.'
-  Enabled: true
-  VersionAdded: '0.52'
-  Include:
-    - app/models/**/*.rb
-
-Rails/LexicallyScopedActionFilter:
-  Description: "Checks that methods specified in the filter's `only` or `except` options are explicitly defined in the controller."
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#lexically-scoped-action-filter'
-  Enabled: true
-  Safe: false
-  VersionAdded: '0.52'
-  Include:
-    - app/controllers/**/*.rb
-
-Rails/LinkToBlank:
-  Description: 'Checks that `link_to` with a `target: "_blank"` have a `rel: "noopener"` option passed to them.'
-  Reference: https://mathiasbynens.github.io/rel-noopener/
-  Enabled: true
-  VersionAdded: '0.62'
-
-Rails/NotNullColumn:
-  Description: 'Do not add a NOT NULL column without a default value'
-  Enabled: true
-  VersionAdded: '0.43'
-  Include:
-    - db/migrate/*.rb
-
-Rails/Output:
-  Description: 'Checks for calls to puts, print, etc.'
-  Enabled: true
-  VersionAdded: '0.15'
-  VersionChanged: '0.19'
-  Include:
-    - app/**/*.rb
-    - config/**/*.rb
-    - db/**/*.rb
-    - lib/**/*.rb
-
-Rails/OutputSafety:
-  Description: 'The use of `html_safe` or `raw` may be a security risk.'
-  Enabled: true
-  VersionAdded: '0.41'
-
-Rails/PluralizationGrammar:
-  Description: 'Checks for incorrect grammar when using methods like `3.day.ago`.'
-  Enabled: true
-  VersionAdded: '0.35'
-
-Rails/Presence:
-  Description: 'Checks code that can be written more easily using `Object#presence` defined by Active Support.'
-  Enabled: true
-  VersionAdded: '0.52'
-
-Rails/Present:
-  Description: 'Enforces use of `present?`.'
-  Enabled: true
-  VersionAdded: '0.48'
-  VersionChanged: '0.67'
-  # Convert usages of `!nil? && !empty?` to `present?`
-  NotNilAndNotEmpty: true
-  # Convert usages of `!blank?` to `present?`
-  NotBlank: true
-  # Convert usages of `unless blank?` to `if present?`
-  UnlessBlank: true
-
-Rails/ReadWriteAttribute:
-  Description: >-
-                 Checks for read_attribute(:attr) and
-                 write_attribute(:attr, val).
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#read-attribute'
-  Enabled: true
-  VersionAdded: '0.20'
-  VersionChanged: '0.29'
-  Include:
-    - app/models/**/*.rb
-
-Rails/RedundantAllowNil:
-  Description: >-
-                 Finds redundant use of `allow_nil` when `allow_blank` is set to
-                 certain values in model validations.
-  Enabled: true
-  VersionAdded: '0.67'
-  Include:
-    - app/models/**/*.rb
-
-Rails/RedundantReceiverInWithOptions:
-  Description: 'Checks for redundant receiver in `with_options`.'
-  Enabled: true
-  VersionAdded: '0.52'
-
-Rails/ReflectionClassName:
-  Description: 'Use a string for `class_name` option value in the definition of a reflection.'
-  Enabled: true
-  VersionAdded: '0.64'
-
-Rails/RefuteMethods:
-  Description: 'Use `assert_not` methods instead of `refute` methods.'
-  Enabled: true
-  VersionAdded: '0.56'
-  Include:
-    - '**/test/**/*'
-
-Rails/RelativeDateConstant:
-  Description: 'Do not assign relative date to constants.'
-  Enabled: true
-  VersionAdded: '0.48'
-  VersionChanged: '0.59'
-  AutoCorrect: false
-
-Rails/RequestReferer:
-  Description: 'Use consistent syntax for request.referer.'
-  Enabled: true
-  VersionAdded: '0.41'
-  EnforcedStyle: referer
-  SupportedStyles:
-    - referer
-    - referrer
-
-Rails/ReversibleMigration:
-  Description: 'Checks whether the change method of the migration file is reversible.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#reversible-migration'
-  Reference: 'https://api.rubyonrails.org/classes/ActiveRecord/Migration/CommandRecorder.html'
-  Enabled: true
-  VersionAdded: '0.47'
-  Include:
-    - db/migrate/*.rb
-
-Rails/SafeNavigation:
-  Description: "Use Ruby's safe navigation operator (`&.`) instead of `try!`"
-  Enabled: true
-  VersionAdded: '0.43'
-  # This will convert usages of `try` to use safe navigation as well as `try!`.
-  # `try` and `try!` work slightly differently. `try!` and safe navigation will
-  # both raise a `NoMethodError` if the receiver of the method call does not
-  # implement the intended method. `try` will not raise an exception for this.
-  ConvertTry: false
-
-Rails/SaveBang:
-  Description: 'Identifies possible cases where Active Record save! or related should be used.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#save-bang'
-  Enabled: false
-  VersionAdded: '0.42'
-  VersionChanged: '0.59'
-  AllowImplicitReturn: true
-  AllowedReceivers: []
-
-Rails/ScopeArgs:
-  Description: 'Checks the arguments of ActiveRecord scopes.'
-  Enabled: true
-  VersionAdded: '0.19'
-  Include:
-    - app/models/**/*.rb
-
-Rails/SkipsModelValidations:
-  Description: >-
-                 Use methods that skips model validations with caution.
-                 See reference for more information.
-  Reference: 'https://guides.rubyonrails.org/active_record_validations.html#skipping-validations'
-  Enabled: true
-  VersionAdded: '0.47'
-  VersionChanged: '0.60'
-  Blacklist:
-    - decrement!
-    - decrement_counter
-    - increment!
-    - increment_counter
-    - toggle!
-    - touch
-    - update_all
-    - update_attribute
-    - update_column
-    - update_columns
-    - update_counters
-  Whitelist: []
-
-Rails/TimeZone:
-  Description: 'Checks the correct usage of time zone aware methods.'
-  StyleGuide: 'https://github.com/rubocop-hq/rails-style-guide#time'
-  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
-  Enabled: true
-  Safe: false
-  VersionAdded: '0.30'
-  VersionChanged: '0.68'
-  # The value `strict` means that `Time` should be used with `zone`.
-  # The value `flexible` allows usage of `in_time_zone` instead of `zone`.
-  EnforcedStyle: flexible
-  SupportedStyles:
-    - strict
-    - flexible
-
-Rails/UniqBeforePluck:
-  Description: 'Prefer the use of uniq or distinct before pluck.'
-  Enabled: true
-  VersionAdded: '0.40'
-  VersionChanged: '0.47'
-  EnforcedStyle: conservative
-  SupportedStyles:
-    - conservative
-    - aggressive
-  AutoCorrect: false
-
-Rails/UnknownEnv:
-  Description: 'Use correct environment name.'
-  Enabled: true
-  VersionAdded: '0.51'
-  Environments:
-    - development
-    - test
-    - production
-
-Rails/Validation:
-  Description: 'Use validates :attribute, hash of validations.'
-  Enabled: true
-  VersionAdded: '0.9'
-  VersionChanged: '0.41'
-  Include:
-    - app/models/**/*.rb
 
 #################### Security ##############################
 
@@ -2573,7 +2171,7 @@ Style/AccessModifierDeclarations:
 
 Style/Alias:
   Description: 'Use alias instead of alias_method.'
-  StyleGuide: '#alias-method'
+  StyleGuide: '#alias-method-lexically'
   Enabled: true
   VersionAdded: '0.9'
   VersionChanged: '0.36'
@@ -2924,6 +2522,13 @@ Style/ConditionalAssignment:
   SingleLineConditionsOnly: true
   IncludeTernaryExpressions: true
 
+Style/ConstantVisibility:
+  Description: >-
+                 Check that class- and module constants have
+                 visibility declarations.
+  Enabled: false
+  VersionAdded: '0.66'
+
 # Checks that you have put a copyright in a comment before any code.
 #
 # You can override the default Notice in your .rubocop.yml file.
@@ -2942,13 +2547,6 @@ Style/ConditionalAssignment:
 #   Notice: 'Copyright (\(c\) )?2015 Yahoo! Inc'
 #   AutocorrectNotice: '# Copyright (c) 2015 Yahoo! Inc.'
 #
-Style/ConstantVisibility:
-  Description: >-
-                 Check that class- and module constants have
-                 visibility declarations.
-  Enabled: false
-  VersionAdded: '0.66'
-
 Style/Copyright:
   Description: 'Include a copyright notice in each file before any code.'
   Enabled: false
@@ -2994,6 +2592,11 @@ Style/DocumentationMethod:
     - 'spec/**/*'
     - 'test/**/*'
   RequireForNonPublicMethods: false
+
+Style/DoubleCopDisableDirective:
+  Description: 'Checks for double rubocop:disable comments on a single line.'
+  Enabled: true
+  VersionAdded: '0.73'
 
 Style/DoubleNegation:
   Description: 'Checks for uses of double negation (!!).'
@@ -3079,7 +2682,7 @@ Style/EvalWithLocation:
   VersionAdded: '0.52'
 
 Style/EvenOdd:
-  Description: 'Favor the use of Integer#even? && Integer#odd?'
+  Description: 'Favor the use of `Integer#even?` && `Integer#odd?`.'
   StyleGuide: '#predicate-methods'
   Enabled: true
   VersionAdded: '0.12'
@@ -3089,6 +2692,19 @@ Style/ExpandPathArguments:
   Description: "Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`."
   Enabled: true
   VersionAdded: '0.53'
+
+Style/FloatDivision:
+  Description: 'For performing float division, coerce one side only.'
+  StyleGuide: '#float-division'
+  Reference: 'https://github.com/rubocop-hq/ruby-style-guide/issues/628'
+  Enabled: true
+  VersionAdded: '0.72'
+  EnforcedStyle: single_coerce
+  SupportedStyles:
+    - left_coerce
+    - right_coerce
+    - single_coerce
+    - fdiv
 
 Style/For:
   Description: 'Checks use of for or each in multiline loops.'
@@ -3125,7 +2741,7 @@ Style/FormatStringToken:
     - template
     - unannotated
   VersionAdded: '0.49'
-  VersionChanged: '0.52'
+  VersionChanged: '0.75'
 
 Style/FrozenStringLiteralComment:
   Description: >-
@@ -3133,12 +2749,9 @@ Style/FrozenStringLiteralComment:
                  to help transition to frozen string literals by default.
   Enabled: true
   VersionAdded: '0.36'
-  VersionChanged: '0.47'
-  EnforcedStyle: when_needed
+  VersionChanged: '0.69'
+  EnforcedStyle: always
   SupportedStyles:
-    # `when_needed` will add the frozen string literal comment to files
-    # only when the `TargetRubyVersion` is set to 2.3+.
-    - when_needed
     # `always` will always add the frozen string literal comment to a file
     # regardless of the Ruby version or if `freeze` or `<<` are called on a
     # string literal. If you run code against multiple versions of Ruby, it is
@@ -3158,7 +2771,7 @@ Style/GlobalVars:
   AllowedVariables: []
 
 Style/GuardClause:
-  Description: 'Check for conditionals that can be replaced with guard clauses'
+  Description: 'Check for conditionals that can be replaced with guard clauses.'
   StyleGuide: '#no-nested-conditionals'
   Enabled: true
   VersionAdded: '0.20'
@@ -3201,6 +2814,7 @@ Style/IdenticalConditionalBranches:
 Style/IfInsideElse:
   Description: 'Finds if nodes inside else, which can be converted to elsif.'
   Enabled: true
+  AllowIfModifier: false
   VersionAdded: '0.36'
 
 Style/IfUnlessModifier:
@@ -3275,8 +2889,9 @@ Style/IpAddresses:
   Description: "Don't include literal IP addresses in code."
   Enabled: false
   VersionAdded: '0.58'
-  # Allow strings to be whitelisted
-  Whitelist:
+  VersionChanged: '0.77'
+  # Allow addresses to be permitted
+  AllowedAddresses:
     - "::"
     # :: is a valid IPv6 address, but could potentially be legitimately in code
 
@@ -3320,6 +2935,7 @@ Style/MethodCallWithArgsParentheses:
   VersionChanged: '0.61'
   IgnoreMacros: true
   IgnoredMethods: []
+  IgnoredPatterns: []
   IncludedMacros: []
   AllowParenthesesInMultilineCall: false
   AllowParenthesesInChaining: false
@@ -3366,7 +2982,7 @@ Style/MethodMissingSuper:
 Style/MinMax:
   Description: >-
                  Use `Enumerable#minmax` instead of `Enumerable#min`
-                 and `Enumerable#max` in conjunction.'
+                 and `Enumerable#max` in conjunction.
   Enabled: true
   VersionAdded: '0.50'
 
@@ -3376,7 +2992,7 @@ Style/MissingElse:
                 If enabled, it is recommended that
                 Style/UnlessElse and Style/EmptyElse be enabled.
                 This will conflict with Style/EmptyElse if
-                Style/EmptyElse is configured to style "both"
+                Style/EmptyElse is configured to style "both".
   Enabled: false
   VersionAdded: '0.30'
   VersionChanged: '0.38'
@@ -3470,6 +3086,12 @@ Style/MultilineTernaryOperator:
   Enabled: true
   VersionAdded: '0.9'
 
+Style/MultilineWhenThen:
+  Description: 'Do not use then for multi-line when statement.'
+  StyleGuide: '#no-then'
+  Enabled: true
+  VersionAdded: '0.73'
+
 Style/MultipleComparison:
   Description: >-
                  Avoid comparing a variable with multiple items in a conditional,
@@ -3510,6 +3132,20 @@ Style/NegatedIf:
     - prefix
     - postfix
 
+Style/NegatedUnless:
+  Description: 'Favor if over unless for negative conditions.'
+  StyleGuide: '#if-for-negatives'
+  Enabled: true
+  VersionAdded: '0.69'
+  EnforcedStyle: both
+  SupportedStyles:
+    # both: prefix and postfix negated `unless` should both use `if`
+    # prefix: only use `if` for negated `unless` statements positioned before the body of the statement
+    # postfix: only use `if` for negated `unless` statements positioned after the body of the statement
+    - both
+    - prefix
+    - postfix
+
 Style/NegatedWhile:
   Description: 'Favor until over while for negative conditions.'
   StyleGuide: '#until-for-negatives'
@@ -3528,8 +3164,8 @@ Style/NestedParenthesizedCalls:
                  argument list of another parenthesized method call.
   Enabled: true
   VersionAdded: '0.36'
-  VersionChanged: '0.50'
-  Whitelist:
+  VersionChanged: '0.77'
+  AllowedMethods:
     - be
     - be_a
     - be_an
@@ -3674,7 +3310,7 @@ Style/OptionHash:
 Style/OptionalArguments:
   Description: >-
                  Checks for optional arguments that do not appear at the end
-                 of the argument list
+                 of the argument list.
   StyleGuide: '#optional-arguments'
   Enabled: true
   VersionAdded: '0.33'
@@ -3706,7 +3342,7 @@ Style/ParenthesesAroundCondition:
   AllowInMultilineConditions: false
 
 Style/PercentLiteralDelimiters:
-  Description: 'Use `%`-literal delimiters consistently'
+  Description: 'Use `%`-literal delimiters consistently.'
   StyleGuide: '#percent-literal-braces'
   Enabled: true
   VersionAdded: '0.19'
@@ -3741,8 +3377,9 @@ Style/PreferredHashMethods:
   Description: 'Checks use of `has_key?` and `has_value?` Hash methods.'
   StyleGuide: '#hash-key'
   Enabled: true
+  Safe: false
   VersionAdded: '0.41'
-  VersionChanged: '0.44'
+  VersionChanged: '0.70'
   EnforcedStyle: short
   SupportedStyles:
     - short
@@ -3781,6 +3418,16 @@ Style/RedundantBegin:
   VersionAdded: '0.10'
   VersionChanged: '0.21'
 
+Style/RedundantCapitalW:
+  Description: 'Checks for %W when interpolation is not needed.'
+  Enabled: true
+  VersionAdded: '0.76'
+
+Style/RedundantCondition:
+  Description: 'Checks for unnecessary conditional expressions.'
+  Enabled: true
+  VersionAdded: '0.76'
+
 Style/RedundantConditional:
   Description: "Don't return true/false from a conditional."
   Enabled: true
@@ -3799,10 +3446,21 @@ Style/RedundantFreeze:
   VersionAdded: '0.34'
   VersionChanged: '0.66'
 
+Style/RedundantInterpolation:
+  Description: 'Checks for strings that are just an interpolated expression.'
+  Enabled: true
+  VersionAdded: '0.76'
+
 Style/RedundantParentheses:
   Description: "Checks for parentheses that seem not to serve any purpose."
   Enabled: true
   VersionAdded: '0.36'
+
+Style/RedundantPercentQ:
+  Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
+  StyleGuide: '#percent-q'
+  Enabled: true
+  VersionAdded: '0.76'
 
 Style/RedundantReturn:
   Description: "Don't use return where it's not required."
@@ -3819,6 +3477,13 @@ Style/RedundantSelf:
   Enabled: true
   VersionAdded: '0.10'
   VersionChanged: '0.13'
+
+Style/RedundantSort:
+  Description: >-
+                  Use `min` instead of `sort.first`,
+                  `max_by` instead of `sort_by...last`, etc.
+  Enabled: true
+  VersionAdded: '0.76'
 
 Style/RedundantSortBy:
   Description: 'Use `sort` instead of `sort_by { |x| x }`.'
@@ -3877,11 +3542,11 @@ Style/SafeNavigation:
                   safe navigation (`&.`).
   Enabled: true
   VersionAdded: '0.43'
-  VersionChanged: '0.56'
+  VersionChanged: '0.77'
   # Safe navigation may cause a statement to start returning `nil` in addition
   # to whatever it used to return.
   ConvertCodeThatCanStartToReturnNil: false
-  Whitelist:
+  AllowedMethods:
     - present?
     - blank?
     - presence
@@ -3986,6 +3651,8 @@ Style/StringHashKeys:
   StyleGuide: '#symbols-as-keys'
   Enabled: false
   VersionAdded: '0.52'
+  VersionChanged: '0.75'
+  Safe: false
 
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'
@@ -4157,7 +3824,7 @@ Style/TrivialAccessors:
   StyleGuide: '#attr_family'
   Enabled: true
   VersionAdded: '0.9'
-  VersionChanged: '0.38'
+  VersionChanged: '0.77'
   # When set to `false` the cop will suggest the use of accessor methods
   # in situations like:
   #
@@ -4178,7 +3845,7 @@ Style/TrivialAccessors:
   # Commonly used in DSLs
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
+  AllowedMethods:
     - to_ary
     - to_a
     - to_c
@@ -4205,39 +3872,10 @@ Style/UnlessElse:
   Enabled: true
   VersionAdded: '0.9'
 
-Style/UnneededCapitalW:
-  Description: 'Checks for %W when interpolation is not needed.'
-  Enabled: true
-  VersionAdded: '0.21'
-  VersionChanged: '0.24'
-
-Style/UnneededCondition:
-  Description: 'Checks for unnecessary conditional expressions.'
-  Enabled: true
-  VersionAdded: '0.57'
-
-Style/UnneededInterpolation:
-  Description: 'Checks for strings that are just an interpolated expression.'
-  Enabled: true
-  VersionAdded: '0.36'
-
-Style/UnneededPercentQ:
-  Description: 'Checks for %q/%Q when single quotes or double quotes would do.'
-  StyleGuide: '#percent-q'
-  Enabled: true
-  VersionAdded: '0.24'
-
-Style/UnneededSort:
-  Description: >-
-                  Use `min` instead of `sort.first`,
-                  `max_by` instead of `sort_by...last`, etc.
-  Enabled: true
-  VersionAdded: '0.55'
-
 Style/UnpackFirst:
   Description: >-
                  Checks for accessing the first element of `String#unpack`
-                 instead of using `unpack1`
+                 instead of using `unpack1`.
   Enabled: true
   VersionAdded: '0.54'
 
@@ -4288,7 +3926,7 @@ Style/WordArray:
   # whose element count is greater than or equal to `MinSize`.
   MinSize: 2
   # The regular expression `WordRegex` decides what is considered a word.
-  WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
+  WordRegex: !ruby/regexp '/\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z/'
 
 Style/YodaCondition:
   Description: 'Forbid or enforce yoda conditions.'
@@ -4304,8 +3942,9 @@ Style/YodaCondition:
     - require_for_all_comparison_operators
     # enforce yoda only for equality operators: `!=` and `==`
     - require_for_equality_operators_only
+  Safe: false
   VersionAdded: '0.49'
-  VersionChanged: '0.63'
+  VersionChanged: '0.75'
 
 Style/ZeroLengthPredicate:
   Description: 'Use #empty? when testing for objects of length 0.'

--- a/silvercop.gemspec
+++ b/silvercop.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = 'silvercop'
-  spec.version = '1.0.1'
+  spec.version = '1.0.2'
   spec.summary = 'Silvercar RuboCop'
   spec.description = 'Code style checking for Silvercar Ruby repositories.'
 
@@ -11,8 +11,10 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['README.md', 'LICENSE', '.rubocop.yml', 'config/*.yml', 'lib/**/*.rb']
 
-  spec.add_dependency 'rubocop', '0.68.1'
-  spec.add_dependency 'rubocop-performance', '1.2.0'
+  spec.add_dependency 'rubocop', '0.77.0'
+  spec.add_dependency 'rubocop-performance', '1.5.1'
+  spec.add_dependency 'rubocop-rails', '2.4.0'
+  spec.add_dependency 'rubocop-thread_safety', '0.3.4'
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
#### Purpose
- [ ] Feature
- [ ] Bug Fix
- [X] Other (Update dependency libraries)

#### Associated Tickets
None

#### Details
Use latest version of rubocop (0.77.0) and rubocop-performance (1.5.1),
add rubocop-thread_safety (0.3.4), add rubocop-rails (2.4.0).

Remove `-R` option since that's included as part of the `rubocop-rails` requirement now.

Add known issue about `Style/TrivialAccessors` warning.
