### PR TITLE
[NO-TKT] - Updating rubocop from   '1.18.4' to '1.44.0'

### DIFF
--- a/silvercop.gemspec
+++ b/silvercop.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = 'silvercop'
-  spec.version = '1.0.4'
+  spec.version = '1.0.5'
   spec.summary = 'Silvercar RuboCop'
   spec.description = 'Code style checking for Silvercar Ruby repositories.'
 
@@ -11,11 +11,11 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['README.md', 'LICENSE', '.rubocop.yml', 'config/*.yml', 'lib/**/*.rb']
 
-  spec.add_dependency 'rubocop', '1.18.4'
-  spec.add_dependency 'rubocop-performance', '1.11.4'
-  spec.add_dependency 'rubocop-rails', '2.11.3'
+  spec.add_dependency 'rubocop', '1.44.0'
+  spec.add_dependency 'rubocop-performance', '1.15.2'
+  spec.add_dependency 'rubocop-rails', '2.17.4'
   spec.add_dependency 'rubocop-rake', '0.6.0'
-  spec.add_dependency 'rubocop-thread_safety', '0.4.1'
+  spec.add_dependency 'rubocop-thread_safety', '0.4.4'
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/silvercop.gemspec
+++ b/silvercop.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = 'silvercop'
-  spec.version = '1.0.5'
+  spec.version = '1.1.0'
   spec.summary = 'Silvercar RuboCop'
   spec.description = 'Code style checking for Silvercar Ruby repositories.'
 
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-performance', '1.15.2'
   spec.add_dependency 'rubocop-rails', '2.17.4'
   spec.add_dependency 'rubocop-rake', '0.6.0'
+  spec.add_dependency 'rubocop-rspec', '2.18.1'
   spec.add_dependency 'rubocop-thread_safety', '0.4.4'
 
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
- rubocop-performance   '1.11.4' to '1.15.2'
- rubocop-rails         '2.11.3' to '2.17.4'
- rubocop-thread_safety '0.4.1'  to '0.4.4'

#### Purpose
- [ ] Feature
- [ ] Bug Fix
- [x] Other

#### Associated Tickets
- n/a

#### Details
Refresh rubocop versions. Bumped version to 1.1.0 because older versions of our ruby/rails apps may not play as nicely (unconfirmed). 
