### PR TITLE
[B2C-1371] Updated rubocop version '1.44.0' -> '1.48.0'

### DIFF
--- a/silvercop.gemspec
+++ b/silvercop.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['README.md', 'LICENSE', '.rubocop.yml', 'config/*.yml', 'lib/**/*.rb']
 
-  spec.add_dependency 'rubocop', '1.48.0'
+  spec.add_dependency 'rubocop', '1.59.0'
   spec.add_dependency 'rubocop-performance', '1.20.1'
   spec.add_dependency 'rubocop-rails', '2.23.1'
   spec.add_dependency 'rubocop-rake', '0.6.0'

--- a/silvercop.gemspec
+++ b/silvercop.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = 'silvercop'
-  spec.version = '1.0.4'
+  spec.version = '1.2.0'
   spec.summary = 'Silvercar RuboCop'
   spec.description = 'Code style checking for Silvercar Ruby repositories.'
 
@@ -11,11 +11,12 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['README.md', 'LICENSE', '.rubocop.yml', 'config/*.yml', 'lib/**/*.rb']
 
-  spec.add_dependency 'rubocop', '1.18.4'
-  spec.add_dependency 'rubocop-performance', '1.11.4'
-  spec.add_dependency 'rubocop-rails', '2.11.3'
+  spec.add_dependency 'rubocop', '1.48.0'
+  spec.add_dependency 'rubocop-performance', '1.20.1'
+  spec.add_dependency 'rubocop-rails', '2.23.1'
   spec.add_dependency 'rubocop-rake', '0.6.0'
-  spec.add_dependency 'rubocop-thread_safety', '0.4.1'
+  spec.add_dependency 'rubocop-rspec', '2.25.0'
+  spec.add_dependency 'rubocop-thread_safety', '0.5.1'
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
#### Purpose
- [ ] Feature
- [ ] Bug Fix
- [x] Other

#### Associated Tickets
- [API | Ruby upgrade 3.3](https://silvercar.atlassian.net/browse/B2C-1371)

#### Details
Upgrading rubocop gems in conjunction with an upgrade of ruby version for b2c-api 
